### PR TITLE
Add file for WezTerm scheme

### DIFF
--- a/wezterm/Rigel.toml
+++ b/wezterm/Rigel.toml
@@ -1,0 +1,33 @@
+# A Rigel colorscheme file for WezTerm
+# Install instructions at https://wezfurlong.org/wezterm/config/appearance.html
+# Short version: 
+#   place this file in ~/.config/wezters/colors on POSIX or in a directory named
+#   "colors" in the same directory as "wezterm.exe" if you are on Windows
+#   Then add `color_scheme = "Rigel"` to your wezterm.lua
+
+[colors]
+background = "#002635"
+foreground = "#e6e6dc"
+cursor_bg = "#ffcc1b"
+cursor_border = "#ffcc1b"
+cursor_fg = "#002635"
+selection_fg = "#002635"
+selection_bg = "#fffacd"
+
+ansi = ["#00384d"
+       , "#c43061"
+       , "#7fc06e"
+       , "#f08e48"
+       , "#1c8db2"
+       , "#c694ff"
+       , "#00cccc"
+       , "#77929e"]
+
+bright = ["#517f8d"
+         , "#ff5a67"
+         , "#9cf087"
+         , "#ffcc1b"
+         , "#7eb2dd"
+         , "#fb94ff"
+         , "#00ffff"
+         , "#b7cff9"]


### PR DESCRIPTION
This commit adds a `Rigel.toml` file for use with the WezTerm terminal emulator.

Because there may be other terminals that use `.toml` files for configuration in the future, I've placed the file in its own directory. Comments at the top of the file describe the short-form installation instructions and contain a link to the main documentation for WezTerm.

Let me know if there's anything that needs to be changed, and thanks for your work on this scheme! I don't think I've ever stuck with a single colorscheme as long as I have with this one.